### PR TITLE
TTK-13731 Use correct id to get the annotations

### DIFF
--- a/Controller/BasePlayerController.php
+++ b/Controller/BasePlayerController.php
@@ -18,7 +18,7 @@ class BasePlayerController extends BasePlayerControllero
     public function magicAction(MultimediaObject $multimediaObject, Request $request)
     {
         if (!$request->query->has('secret')) {
-            return $this->redirect($this->generateUrl('pumukit_videoplayer_magicindex', array('id' => $multimediaObject->getSecret(), 'secret' => $multimediaObject->getSecret())).'&secret='.$multimediaObject->getSecret());
+            return $this->redirect($this->generateUrl('pumukit_videoplayer_magicindex', array('id' => $multimediaObject->getId(), 'secret' => $multimediaObject->getSecret())).'&secret='.$multimediaObject->getSecret());
         }
 
         $response = $this->testBroadcast($multimediaObject, $request);

--- a/Resources/public/assets/paella_start.js
+++ b/Resources/public/assets/paella_start.js
@@ -42,10 +42,10 @@ var MyVideoLoader = Class.create(paella.DefaultVideoLoader, {
             var repo_url = '/paellarepository/' + videoId
             var trackId = paella.utils.parameters.get('track_id')
             var secret = paella.utils.parameters.get('secret')
+            if(secret)
+                repo_url = '/secret/paellarepository/' + secret
             if(trackId)
                 repo_url += '?track_id=' + trackId
-            else if(secret)
-                repo_url = '/secret' + repo_url
             $.get(repo_url)
                 .done(function(data){
                     var This = that;


### PR DESCRIPTION
When a multimedia object is hidden, the secret has been used to get the annotations instead of the id