### PR TITLE
TTK-13695 templates: Added 'setProfile' function to fully set the paella profile

### DIFF
--- a/Resources/views/PaellaPlayer/player.html.twig
+++ b/Resources/views/PaellaPlayer/player.html.twig
@@ -23,10 +23,17 @@
        {% endif %}
 
        setTimeout(function(){
+           setPaellaProfile("{{ getPaellaLayout(multimediaObject, app.request) }}");
            paella.player.setProfile("{{ getPaellaLayout(multimediaObject, app.request) }}");
        }, 300);
 
    });
    loadPaella('playerContainer', '{{multimediaObject.id}}');
+   function setPaellaProfile(profileName) {
+       $('.viewModeItemButton').removeClass('selected');
+       $('.viewModeItemButton.' + profileName).addClass('selected');
+       paella.player.setProfile(profileName);
+       base.cookies.set("lastProfile", profileName);
+   }
   </script>
 {% endblock %}

--- a/Resources/views/PaellaPlayer/player.html.twig
+++ b/Resources/views/PaellaPlayer/player.html.twig
@@ -24,7 +24,6 @@
 
        setTimeout(function(){
            setPaellaProfile("{{ getPaellaLayout(multimediaObject, app.request) }}");
-           paella.player.setProfile("{{ getPaellaLayout(multimediaObject, app.request) }}");
        }, 300);
 
    });


### PR DESCRIPTION
**Note:** Should we add this to earlier versions than 1.2.x? (I.e. 1.1.x or 1.0.x)?