### PR TITLE
TTK-17188 PaellaDataService: Included all display sources if several.

### DIFF
--- a/Services/PaellaDataService.php
+++ b/Services/PaellaDataService.php
@@ -4,7 +4,6 @@ namespace Pumukit\PaellaPlayerBundle\Services;
 
 use Pumukit\SchemaBundle\Document\MultimediaObject;
 use Pumukit\SchemaBundle\Document\Series;
-use Pumukit\SchemaBundle\Document\Track;
 use Pumukit\SchemaBundle\Services\PicService;
 use Pumukit\SchemaBundle\Services\MaterialService;
 use Pumukit\BasePlayerBundle\Services\TrackUrlService;
@@ -98,7 +97,7 @@ class PaellaDataService
             }
 
             if ($track) {
-                $dataStream = $this->buildDataStream($track, $request);
+                $dataStream = $this->buildDataStream([$track], $request);
                 $pic = $this->picService->getFirstUrlPic($mmobj, true, true);
                 $dataStream['preview'] = $pic;
                 $data['streams'][] = $dataStream;
@@ -288,7 +287,7 @@ class PaellaDataService
     private function buildDataStream(array $tracks, Request $request)
     {
         $sources = array();
-        foreach($tracks as $track){
+        foreach ($tracks as $track) {
             $mimeType = $track->getMimetype();
             $src = $this->getAbsoluteUrl($request, $this->trackService->generateTrackFileUrl($track, true));
 
@@ -302,14 +301,15 @@ class PaellaDataService
                 $dataStreamTrack['res'] = array('w' => $track->getWidth(), 'h' => $track->getHeight());
             }
 
-            $type = explode('/', $mimeType)[1];
-            if (!isset($sources[$type])) {
-                $sources[$type] = array();
+            //$format = explode('/', $mimeType)[1] ?? 'mp4'; // FOR PHP 7
+            $format = isset(explode('/', $mimeType)[1]) ? explode('/', $mimeType)[1] : 'mp4';
+
+            if (!isset($sources[$format])) {
+                $sources[$format] = array();
             }
-            $sources[$type][] = $dataStreamTrack;
+            $sources[$format][] = $dataStreamTrack;
         }
         $dataStream['sources'] = $sources;
-
 
         return $dataStream;
     }

--- a/Services/PaellaDataService.php
+++ b/Services/PaellaDataService.php
@@ -165,20 +165,20 @@ class PaellaDataService
     private function getMmobjTracks(MultimediaObject $mmobj, $trackId)
     {
         $tracks = array(
-            'display' => false,
-            'presentation' => false,
-            'sbs' => false,
+            'display' => array(),
+            'presentation' => array(),
+            'sbs' => array(),
         );
         $availableCodecs = array('h264', 'vp8', 'vp9');
 
         if ($trackId) {
             $track = $mmobj->getTrackById($trackId);
             if ($track->containsAnyTag(array('display', 'presenter/delivery', 'presentation/delivery')) && in_array($track->getVcodec(), $availableCodecs)) {
-                $tracks['display'] = $track;
+                $tracks['display'][] = $track;
             }
 
             if ($track->isOnlyAudio()) {
-                $tracks['display'] = $track;
+                $tracks['display'][] = $track;
             }
 
             return $tracks;
@@ -190,25 +190,23 @@ class PaellaDataService
 
         foreach ($presenterTracks as $track) {
             if (in_array($track->getVcodec(), $availableCodecs)) {
-                $tracks['display'] = $track;
-                break;
+                $tracks['display'][] = $track;
             }
         }
         foreach ($presentationTracks as $track) {
             if (in_array($track->getVcodec(), $availableCodecs)) {
-                $tracks['presentation'] = $track;
-                break;
+                $tracks['presentation'][] = $track;
             }
         }
 
         if ($sbsTrack && in_array($sbsTrack->getVcodec(), $availableCodecs)) {
-            $tracks['sbs'] = $sbsTrack;
+            $tracks['sbs'][] = $sbsTrack;
         }
 
         if (!$tracks['display'] && !$tracks['presentation']) {
             $track = $mmobj->getDisplayTrack();
             if ($track && in_array($track->getVcodec(), $availableCodecs)) {
-                $tracks['display'] = $track;
+                $tracks['display'][] = $track;
             }
         }
 
@@ -287,25 +285,31 @@ class PaellaDataService
     /**
      * Returns a data array with the required paella structure for a 'data stream'.
      */
-    private function buildDataStream(Track $track, Request $request)
+    private function buildDataStream(array $tracks, Request $request)
     {
-        $src = $this->getAbsoluteUrl($request, $this->trackService->generateTrackFileUrl($track, true));
-        $mimeType = $track->getMimetype();
-        $dataStream = array(
-            'sources' => array(
-                'mp4' => array(
-                    array(
-                        'src' => $src,
-                        'mimetype' => $mimeType,
-                    ),
-                ),
-            ),
-        );
+        $sources = array();
+        foreach($tracks as $track){
+            $mimeType = $track->getMimetype();
+            $src = $this->getAbsoluteUrl($request, $this->trackService->generateTrackFileUrl($track, true));
 
-        // If pumukit doesn't know the resolution, paella can guess it.
-        if ($track->getWidth() && $track->getHeight()) {
-            $dataStream['sources']['mp4'][0]['res'] = array('w' => $track->getWidth(), 'h' => $track->getHeight());
+            $dataStreamTrack = array(
+                'src' => $src,
+                'mimetype' => $mimeType,
+            );
+
+            // If pumukit doesn't know the resolution, paella can guess it.
+            if ($track->getWidth() && $track->getHeight()) {
+                $dataStreamTrack['res'] = array('w' => $track->getWidth(), 'h' => $track->getHeight());
+            }
+
+            $type = explode('/', $mimeType)[1];
+            if (!isset($sources[$type])) {
+                $sources[$type] = array();
+            }
+            $sources[$type][] = $dataStreamTrack;
         }
+        $dataStream['sources'] = $sources;
+
 
         return $dataStream;
     }

--- a/Tests/Controller/PaellaRepositoryControllerTest.php
+++ b/Tests/Controller/PaellaRepositoryControllerTest.php
@@ -50,7 +50,7 @@ class PaellaRepositoryControllerTest extends WebTestCase
         return $response;
     }
 
-    private function makePaellaData($mmobj, $tracks = [])
+    private function makePaellaData($mmobj, $trackLists = [])
     {
         $paellaData = [
             'streams' => [],
@@ -60,19 +60,43 @@ class PaellaRepositoryControllerTest extends WebTestCase
                 'duration' => 0, // $mmobj->getDuration() (The service ALWAYS returns 0)
             ],
         ];
-        foreach ($tracks as $id => $track) {
-            $paellaData['streams'][$id] = [
-                'sources' => [
-                    'mp4' => [
-                        0 => [
-                            'src' => $this->trackUrlService->generateTrackFileUrl($track, true),
-                        ],
-                    ],
-                ],
-            ];
-            if ($track->containsAnyTag(['display', 'presenter/delivery'])) {
-                $paellaData['streams'][$id]['preview'] = $this->picService->getFirstUrlPic($mmobj, true, false);
+        foreach ($trackLists as $id => $tracks) {
+            if (!is_array($tracks)) {
+                $tracks = [$tracks];
             }
+            $sources = array();
+            foreach($tracks as $track){
+                $mimeType = $track->getMimetype();
+                $src = $this->trackUrlService->generateTrackFileUrl($track, true);
+                //$src = $this->getAbsoluteUrl($request, $this->trackService->generateTrackFileUrl($track, true));
+
+                $dataStreamTrack = array(
+                    'src' => $src,
+                    'mimetype' => $mimeType,
+                );
+
+                // If pumukit doesn't know the resolution, paella can guess it.
+                if ($track->getWidth() && $track->getHeight()) {
+                    $dataStreamTrack['res'] = array('w' => $track->getWidth(), 'h' => $track->getHeight());
+                }
+
+                $type = explode('/', $mimeType)[1];
+                if (!isset($sources[$type])) {
+                    $sources[$type] = array();
+                }
+                $sources[$type][] = $dataStreamTrack;
+
+                if ($track->containsAnyTag(['display', 'presenter/delivery']) && !isset($preview)) {
+                    $preview = $this->picService->getFirstUrlPic($mmobj, true, false);
+                }
+            }
+            $paellaData['streams'][$id] = array('sources' => $sources);
+
+            if($preview) {
+                $paellaData['streams'][$id]['preview'] = $preview;
+                $preview = false;
+            }
+
         }
 
         return $paellaData;
@@ -92,6 +116,7 @@ class PaellaRepositoryControllerTest extends WebTestCase
 
         $trackPresenter = new Track();
         $trackPresenter->setDuration(2);
+        $trackPresenter->setMimetype('video/mp4');
         $trackPresenter->setTags(array('display', 'presenter/delivery'));
 
         $mmobj->addTrack($trackPresenter);
@@ -123,11 +148,13 @@ class PaellaRepositoryControllerTest extends WebTestCase
 
         $trackPresentation = new Track();
         $trackPresentation->setDuration(2);
+        $trackPresentation->setMimetype('video/mp4');
         $trackPresentation->setTags(array('presentation/delivery'));
         $trackPresentation->setVcodec('h264');
 
         $trackSBS = new Track();
         $trackSBS->setDuration(2);
+        $trackSBS->setMimetype('video/mp4');
         $trackSBS->setTags(array('sbs'));
 
         $mmobj->addTrack($trackPresentation);
@@ -176,12 +203,14 @@ class PaellaRepositoryControllerTest extends WebTestCase
         $trackPresenter2 = new Track();
         $trackPresenter2->setVcodec('vp8');
         $trackPresenter2->setDuration(2);
+        $trackPresenter2->setMimetype('video/webm');
         $trackPresenter2->setTags(array('presenter/delivery'));
         $mmobj->addTrack($trackPresenter2);
 
         $trackPresenter3 = new Track();
         $trackPresenter3->setVcodec('vp8');
         $trackPresenter3->setDuration(2);
+        $trackPresenter3->setMimetype('video/webm');
         $trackPresenter3->setTags(array('presenter/delivery'));
         $mmobj->addTrack($trackPresenter3);
 
@@ -191,7 +220,7 @@ class PaellaRepositoryControllerTest extends WebTestCase
         //Should return presentation & presenter (not Dup)
         $response = $this->callRepo($mmobj);
         $responseData = json_decode($response->getContent(), true);
-        $this->assertEquals($this->makePaellaData($mmobj, [$trackPresenter, $trackPresentation]), $responseData);
+        $this->assertEquals($this->makePaellaData($mmobj, [[$trackPresenter, $trackPresenter2, $trackPresenter3], $trackPresentation]), $responseData);
 
         //Should return presenterDup
         $response = $this->callRepo($mmobj, $trackPresenter3);
@@ -205,6 +234,7 @@ class PaellaRepositoryControllerTest extends WebTestCase
 
         $trackAudio = new Track();
         $trackAudio->setDuration(2);
+        $trackAudio->setMimetype('audio/mp3');
         $trackAudio->setTags(array('audio', 'display'));
         $trackAudio->setOnlyAudio(true);
 
@@ -228,6 +258,7 @@ class PaellaRepositoryControllerTest extends WebTestCase
         $track = new Track();
         $track->setDuration(2);
         $track->setOnlyAudio(true);
+        $track->setMimetype('audio/mp3');
         $track->setTags(array('display'));
         $mmobj->addTrack($track);
         $mmobj->setType(MultimediaObject::TYPE_AUDIO);
@@ -244,7 +275,7 @@ class PaellaRepositoryControllerTest extends WebTestCase
         $this->assertEquals(count($responseData['streams'][0]['sources']), 1);
 
         $this->assertEquals($this->trackUrlService->generateTrackFileUrl($track, true),
-                            $responseData['streams'][0]['sources']['mp4'][0]['src']);
+                            $responseData['streams'][0]['sources']['mp3'][0]['src']);
     }
 
     public function testMultipleAudioPaellaRepository()


### PR DESCRIPTION
This change should not change anything for a regular MMOBJ. It does two new things:
1. Add the correct source type as category instead of always using 'mp4'
2. If there are several sources of the same type, it adds them all in a list (several displays, several presentations)

The change (2) is of particular interest when having both a webm recording (generated faster) and a mp4 recording (takes longer, but adds support to ie/safari browsers)