### PR TITLE
Deactivate autoplay in Safari

### DIFF
--- a/Controller/BasePlayerController.php
+++ b/Controller/BasePlayerController.php
@@ -106,8 +106,10 @@ class BasePlayerController extends BasePlayerControllero
     {
         $autoStart = $request->query->get('autostart', 'false');
         $userAgent = $request->headers->get('user-agent');
-        if (true === strpos($userAgent, 'Safari')) {
-            $autoStart = false;
+        if (false !== strpos($userAgent, 'Safari')) {
+            if (false === strpos($userAgent, 'Chrome')) {
+                $autoStart = false;
+            }
         }
 
         return $autoStart;


### PR DESCRIPTION
Because Chrome also use the string Safari in his useragent it's necessary to filter this.